### PR TITLE
Fixed thermo entries for two adsorbates on Pt

### DIFF
--- a/input/thermo/groups/adsorptionPt.py
+++ b/input/thermo/groups/adsorptionPt.py
@@ -466,15 +466,14 @@ entry(
 """,
     thermo=ThermoData(
         Tdata=([300, 400, 500, 600, 800, 1000, 1500], 'K'),
-        Cpdata=([-0.22, 0.65, 1.14, 1.4, 1.61, 1.68, 1.77], 'cal/(mol*K)'),
-        H298=(-18.76, 'kcal/mol'),
-        S298=(-32.78, 'cal/(mol*K)'),
+        Cpdata=([1.74, 2.63, 3.12, 3.38, 3.60, 3.67, 3.76], 'cal/(mol*K)'),
+        H298=(-18.32, 'kcal/mol'),
+        S298=(-37.88, 'cal/(mol*K)'),
     ),
     shortDesc=u"""Came from HN-O vdW-bonded on Pt(111)""",
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.270 eV.
             Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -1.26632 eV, gamma_N(X) = 0.000.
-            The two lowest frequencies, 36.2 and 74.0 cm-1, where replaced by the 2D gas model.
 
   RN=O
     :
@@ -1528,6 +1527,7 @@ entry(
     longDesc=u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (files: compute_NASA_for_Pt-adsorbates.ipynb and compute_NASA_for_Pt-gas_phase.ipynb). Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.184 eV.
             Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.18361 eV, gamma_C(X) = 0.000.
+            The two lowest frequencies, 14.8 and 17.3 cm-1, where replaced by the 2D gas model.
 
  R2C=O
     :

--- a/input/thermo/libraries/surfaceThermoPt.py
+++ b/input/thermo/libraries/surfaceThermoPt.py
@@ -400,8 +400,8 @@ entry(
 """,
     thermo = NASA(
         polynomials = [
-            NASAPolynomial(coeffs=[1.08095806E+00, 1.29219267E-02, -1.33374540E-05, 7.75158679E-09, -1.92612419E-12, -8.13728821E+03, 6.08546053E-01], Tmin=(298.0,'K'), Tmax=(1000.0, 'K')),
-            NASAPolynomial(coeffs=[6.47671505E+00, -3.95793547E-03, 7.09299979E-06, -3.80627447E-09, 6.85388388E-13, -9.53610261E+03, -2.67996453E+01], Tmin=(1000.0,'K'), Tmax=(2000.0, 'K')),
+            NASAPolynomial(coeffs=[2.01921198E+00, 1.32114311E-02, -1.38865998E-05, 8.22653204E-09, -2.08098816E-12, -8.20311706E+03, -7.36585097E+00], Tmin=(298.0,'K'), Tmax=(1000.0, 'K')),
+            NASAPolynomial(coeffs=[7.47524490E+00, -3.96252291E-03, 7.10187151E-06, -3.81135481E-09, 6.86348463E-13, -9.61232570E+03, -3.50542781E+01], Tmin=(1000.0,'K'), Tmax=(2000.0, 'K')),
         ],
         Tmin = (298.0, 'K'),
         Tmax = (2000.0, 'K'),
@@ -409,8 +409,7 @@ entry(
     longDesc = u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (file: compute_NASA_for_Pt-adsorbates.ipynb). 
             Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -1.270 eV.
-            Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -1.26632 eV, gamma_N(X) = 0.000.
-            The two lowest frequencies, 36.2 and 74.0 cm-1, where replaced by the 2D gas model.""",
+            Linear scaling parameters: ref_adatom_N = -4.352 eV, psi = -1.26632 eV, gamma_N(X) = 0.000.""",
 )
 
 entry(
@@ -1376,7 +1375,8 @@ entry(
     longDesc = u"""Calculated by Katrin Blondal at Brown University using statistical mechanics (file: compute_NASA_for_Pt-adsorbates.ipynb). 
             Based on DFT calculations by Jelena Jelic at KIT.
             DFT binding energy: -0.184 eV.
-            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.18361 eV, gamma_C(X) = 0.000.""",
+            Linear scaling parameters: ref_adatom_C = -6.750 eV, psi = -0.18361 eV, gamma_C(X) = 0.000.
+            The two lowest frequencies, 14.8 and 17.3 cm-1, where replaced by the 2D gas model.""",
 )
 
 entry(


### PR DESCRIPTION
Added 2D gas comment to entry for *(CH2O).
Switched from using 2D gas model for *(HNO) to using the harmonic oscillator model due to its strong binding energy and fixed entry accordingly.